### PR TITLE
Added more explosive spleef variants, moved to "explosive" folder

### DIFF
--- a/data/nucleoid/games/spleef/explosive/donut.json
+++ b/data/nucleoid/games/spleef/explosive/donut.json
@@ -1,0 +1,33 @@
+{
+    "type": "spleef:spleef",
+    "name": "Donut Explosive Spleef",
+    "map": {
+      "shape": {
+        "type": "spleef:circle",
+        "radius": 32,
+        "inner_radius": 16
+      },
+      "levels": 4,
+      "level_height": 5,
+      "floor_provider": {
+        "type": "minecraft:simple_state_provider",
+        "state": {
+          "Name": "minecraft:snow_block"
+        }
+      },
+      "wall_provider": {
+        "type": "minecraft:simple_state_provider",
+        "state": {
+            "Name": "minecraft:obsidian"
+            }
+        }
+    },
+    "players": {
+      "min": 1,
+      "max": 100,
+      "threshold": 2
+    },
+    "projectile": {"restock_interval":1,"stack":{"id":"minecraft:tnt","Count":1, "tag":{"CanPlaceOn":["minecraft:obsidian","minecraft:snow_block", "minecraft:tnt"]}}},
+    "tool": {"id": "minecraft:flint_and_steel", "Count": 1, "tag":{"CanPlaceOn":["minecraft:tnt"]}},
+    "unstable_tnt": true
+  }

--- a/data/nucleoid/games/spleef/explosive/fast.json
+++ b/data/nucleoid/games/spleef/explosive/fast.json
@@ -1,0 +1,27 @@
+{
+    "type": "spleef:spleef",
+    "name": "Fast Explosive Spleef",
+    "map": {
+      "shape": {
+        "type": "spleef:circle",
+        "radius": 5
+      },
+      "levels": 30,
+      "level_height": 4,
+      "wall_provider": {
+        "type": "minecraft:simple_state_provider",
+        "state": {
+            "Name": "minecraft:obsidian"
+        }
+    }
+    },
+    "level_break_interval": 60,
+    "players": {
+      "min": 1,
+      "max": 100,
+      "threshold": 2
+    },
+    "projectile": {"restock_interval":1,"stack":{"id":"minecraft:tnt","Count":1, "tag":{"CanPlaceOn":["minecraft:obsidian","minecraft:snow_block", "minecraft:tnt"]}}},
+    "tool": {"id": "minecraft:flint_and_steel", "Count": 1, "tag":{"CanPlaceOn":["minecraft:tnt"]}},
+    "unstable_tnt": true
+  }

--- a/data/nucleoid/games/spleef/explosive/tall.json
+++ b/data/nucleoid/games/spleef/explosive/tall.json
@@ -1,0 +1,26 @@
+{
+    "type": "spleef:spleef",
+    "name": "Tall Explosive Spleef",
+    "map": {
+      "shape": {
+        "type": "spleef:circle",
+        "radius": 16
+      },
+      "levels": 6,
+      "level_height": 5,
+      "wall_provider": {
+        "type": "minecraft:simple_state_provider",
+        "state": {
+            "Name": "minecraft:obsidian"
+            }
+        }
+    },
+    "players": {
+      "min": 1,
+      "max": 100,
+      "threshold": 2
+    },
+    "projectile": {"restock_interval":1,"stack":{"id":"minecraft:tnt","Count":1, "tag":{"CanPlaceOn":["minecraft:obsidian","minecraft:snow_block", "minecraft:tnt"]}}},
+    "tool": {"id": "minecraft:flint_and_steel", "Count": 1, "tag":{"CanPlaceOn":["minecraft:tnt"]}},
+    "unstable_tnt": true
+  }

--- a/data/nucleoid/games/spleef/explosive/tater.json
+++ b/data/nucleoid/games/spleef/explosive/tater.json
@@ -34,5 +34,6 @@
         "threshold": 2
     },
     "projectile": {"restock_interval":1,"stack":{"id":"minecraft:tnt","Count":1, "tag":{"CanPlaceOn":["minecraft:obsidian","minecraft:snow_block", "minecraft:tnt"]}}},
-    "tool": {"id": "minecraft:flint_and_steel", "Count": 1, "tag":{"CanPlaceOn":["minecraft:tnt"]}}
+    "tool": {"id": "minecraft:flint_and_steel", "Count": 1, "tag":{"CanPlaceOn":["minecraft:tnt"]}},
+    "unstable_tnt": true
 }

--- a/data/nucleoid/games/spleef/explosive/tater.json
+++ b/data/nucleoid/games/spleef/explosive/tater.json
@@ -1,6 +1,6 @@
 {
     "type": "spleef:spleef",
-    "name": "Tater Exploding Spleef",
+    "name": "Tater Explosive Spleef",
     "map": {
         "shape": {
             "type": "spleef:pattern",


### PR DESCRIPTION
Added more explosive spleef variants, moved to "explosive" folder.
Uses the new `unstable_tnt` config.